### PR TITLE
Pass response

### DIFF
--- a/lib/converse/conversation.rb
+++ b/lib/converse/conversation.rb
@@ -19,9 +19,9 @@ module Converse
       steps << block
     end
 
-    def perform
+    def perform(*args)
       step = steps.pop
-      step.call self unless step.nil?
+      step.call self, *args unless step.nil?
       Converse.unregister_conversation self if steps.empty?
     end
 

--- a/lib/converse/conversation_template_runner.rb
+++ b/lib/converse/conversation_template_runner.rb
@@ -35,7 +35,7 @@ module Converse
           Converse.register_conversation conversation
         end
 
-        conversation.perform
+        conversation.perform message
       end
     end
 

--- a/spec/converse/conversation_spec.rb
+++ b/spec/converse/conversation_spec.rb
@@ -65,5 +65,14 @@ RSpec.describe Converse::Conversation do
 
       expect { subject.perform }.to change { Converse.conversations.count }.by -1
     end
+
+    it "yields the message" do
+      message = double(:message)
+      Converse.register_conversation subject
+
+      expect(proc).to receive(:call).with(subject, message)
+
+      subject.perform message
+    end
   end
 end

--- a/spec/converse/conversation_template_runner_spec.rb
+++ b/spec/converse/conversation_template_runner_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Converse::ConversationTemplateRunner do
       end
 
       it "performs the conversation" do
-        expect_any_instance_of(Converse::Conversation).to receive(:perform)
+        expect_any_instance_of(Converse::Conversation).to receive(:perform).with message
 
         subject.run template
       end


### PR DESCRIPTION
Passes in the original message to the `Conversation#perform` which will allow for the `#ask` method to inspect the response.