### PR TITLE
Diverge conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ A conversation wraps the message and is comprised of several handlers. Each `Con
 #### Defining conversations inline
 
 ```ruby
-Converse.build do
-  name :select_size
-  configure { access_token: ENV["SLACK_ACCESS_TOKEN"] }
-  conversation do |conversation|
-    conversation.ask("What size do you wear?") do |response, conversation|
-      conversation.reply("Gotcha. Size #{response.reply}. Noted.")
-      conversation.ask("What color would you like?") do |response, conversation|
-        conversation.reply("Great.")
-        conversation.continue
-      end
+Converse::ConversationTemplate.build(:order_shirt) do |conversation|
+  conversation.ask("What size do you wear?") do |response, conversation|
+    conversation.reply("Gotcha. Size #{response}. Noted.")
+    conversation.ask("What color would you like?") do |response, conversation|
+      conversation.reply("Great. I have you down for a #{response}.")
+      conversation.end("Thank you for your order.")
     end
   end
-end
+end.register
 ```
 
 You can `reply` to the conversation or `ask` the participant a question.
 
-You can move onto the next flow in the conversation with a `continue` method on a conversation.
+You can move onto a different conversation thread with a `diverge` followed by the name of the conversation.
+
+```
+conversation.diverge :end_order
+```
 
 You `start` a conversation which will store a `user`, a `channel`, and the conversation id. This is the placeholder for the conversation.
 

--- a/lib/converse/conversation.rb
+++ b/lib/converse/conversation.rb
@@ -6,20 +6,35 @@ module Converse
     include Storable
 
     attr_accessor :channel_id, :team_id, :user_id
-    attr_reader :steps, :template
+    attr_reader :message, :steps, :template
 
-    def initialize(template=nil, options={})
+    def initialize(template=nil, message=nil, options={})
       guard_options! options
 
-      @steps = []
       @template = template
+      @steps = []
       @steps << @template.template unless @template.nil?
+
+      @message = message
+      unless @message.nil?
+        @channel_id = message.channel_id
+        @team_id = message.team_id
+        @user_id = message.user_id
+      end
+
       @options = options.freeze
     end
 
     def ask(question, opts={}, &block)
       say question, opts
       steps << block
+    end
+
+    def diverge(template_name)
+      template = Converse.find_template template_name
+      # TODO: Pass in the decorated message from the runner in the
+      # initializer and store that
+      template.start nil, options
     end
 
     def end(statement=nil)

--- a/lib/converse/conversation.rb
+++ b/lib/converse/conversation.rb
@@ -38,7 +38,8 @@ module Converse
       template = Converse.find_template template_name
       unless template.nil?
         templates << template
-        steps.insert(0, template.template)
+        steps << template.template
+        perform
       end
     end
 

--- a/lib/converse/conversation.rb
+++ b/lib/converse/conversation.rb
@@ -32,9 +32,7 @@ module Converse
 
     def diverge(template_name)
       template = Converse.find_template template_name
-      # TODO: Pass in the decorated message from the runner in the
-      # initializer and store that
-      template.start nil, options
+      template.start message&.original_message, options unless template.nil?
     end
 
     def end(statement=nil)

--- a/lib/converse/conversation.rb
+++ b/lib/converse/conversation.rb
@@ -6,14 +6,18 @@ module Converse
     include Storable
 
     attr_accessor :channel_id, :team_id, :user_id
-    attr_reader :message, :steps, :template
+    attr_reader :message, :steps, :templates
 
     def initialize(template=nil, message=nil, options={})
       guard_options! options
 
-      @template = template
+      @templates = []
       @steps = []
-      @steps << @template.template unless @template.nil?
+
+      unless template.nil?
+        @templates = [template]
+        @steps << template.template
+      end
 
       @message = message
       unless @message.nil?
@@ -32,7 +36,10 @@ module Converse
 
     def diverge(template_name)
       template = Converse.find_template template_name
-      template.start message&.original_message, options unless template.nil?
+      unless template.nil?
+        templates << template
+        steps.insert(0, template.template)
+      end
     end
 
     def end(statement=nil)

--- a/lib/converse/conversation_template.rb
+++ b/lib/converse/conversation_template.rb
@@ -11,6 +11,11 @@ module Converse
       ConversationTemplate.new name, &block
     end
 
+    def register
+      Converse.register_template self
+      self
+    end
+
     def start(message, options={})
       ConversationTemplateRunner.new(message, options).run self
     end

--- a/lib/converse/conversation_template_runner.rb
+++ b/lib/converse/conversation_template_runner.rb
@@ -33,7 +33,7 @@ module Converse
           Converse.register_conversation conversation
         end
 
-        conversation.perform
+        conversation.perform decorated_message
       end
     end
 

--- a/lib/converse/conversation_template_runner.rb
+++ b/lib/converse/conversation_template_runner.rb
@@ -28,7 +28,7 @@ module Converse
         if Converse.conversation_registered? user_id, channel_id
           conversation = Converse.find_conversation user_id, channel_id
         else
-          conversation = Conversation.new template, options
+          conversation = Conversation.new template, nil, options
           conversation.channel_id = channel_id
           conversation.team_id = team_id
           conversation.user_id = user_id

--- a/lib/converse/conversation_template_runner.rb
+++ b/lib/converse/conversation_template_runner.rb
@@ -29,19 +29,12 @@ module Converse
           conversation = Converse.find_conversation user_id, channel_id
         else
           conversation = Conversation.new template, decorated_message, options
-          conversation.channel_id = channel_id
-          conversation.team_id = team_id
-          conversation.user_id = user_id
 
           Converse.register_conversation conversation
         end
 
         conversation.perform message
       end
-    end
-
-    def team_id
-      decorated_message.team_id
     end
 
     def user_id

--- a/lib/converse/conversation_template_runner.rb
+++ b/lib/converse/conversation_template_runner.rb
@@ -33,7 +33,7 @@ module Converse
           Converse.register_conversation conversation
         end
 
-        conversation.perform message
+        conversation.perform
       end
     end
 

--- a/lib/converse/conversation_template_runner.rb
+++ b/lib/converse/conversation_template_runner.rb
@@ -28,7 +28,7 @@ module Converse
         if Converse.conversation_registered? user_id, channel_id
           conversation = Converse.find_conversation user_id, channel_id
         else
-          conversation = Conversation.new template, nil, options
+          conversation = Conversation.new template, decorated_message, options
           conversation.channel_id = channel_id
           conversation.team_id = team_id
           conversation.user_id = user_id

--- a/lib/converse/message_decorators/slack.rb
+++ b/lib/converse/message_decorators/slack.rb
@@ -1,10 +1,11 @@
 module Converse
   module MessageDecorators
-    class Slack
+    class Slack < SimpleDelegator
       attr_reader :original_message
 
       def initialize(message)
         @original_message = message
+        __setobj__ @original_message
       end
 
       def channel_id

--- a/spec/converse/conversation_spec.rb
+++ b/spec/converse/conversation_spec.rb
@@ -79,10 +79,10 @@ RSpec.describe Converse::Conversation do
       expect(subject.templates).to eq [template, another_template]
     end
 
-    it "adds the template steps to the top" do
-      expect { subject.diverge :another_template }.to \
-        change { subject.steps.length }.by 1
-      expect(subject.steps.first).to eq another_proc
+    it "performs the template steps" do
+      expect(another_proc).to receive(:call).with(subject)
+
+      subject.diverge :another_template
     end
 
     it "does nothing if the conversation doesn't exist" do

--- a/spec/converse/conversation_spec.rb
+++ b/spec/converse/conversation_spec.rb
@@ -3,8 +3,9 @@ RSpec.describe Converse::Conversation do
 
   describe "#initialize" do
     let(:proc) { Proc.new {} }
+    let(:message) { double(:message, channel_id: "C1", team_id: "T1", user_id: "U1") }
     let(:template) { Converse::ConversationTemplate.new &proc }
-    subject { described_class.new template }
+    subject { described_class.new template, message }
 
     it "is initialized with a template" do
       expect(subject.template).to eq template
@@ -12,6 +13,22 @@ RSpec.describe Converse::Conversation do
 
     it "sets the current step to the template" do
       expect(subject.steps.first).to eq proc
+    end
+
+    it "is initialized with a decorated message" do
+      expect(subject.message).to eq message
+    end
+
+    it "sets the channel id" do
+      expect(subject.channel_id).to eq "C1"
+    end
+
+    it "sets the team id" do
+      expect(subject.team_id).to eq "T1"
+    end
+
+    it "sets the user id" do
+      expect(subject.user_id).to eq "U1"
     end
   end
 
@@ -43,6 +60,22 @@ RSpec.describe Converse::Conversation do
     it "is initialized with an empty hash" do
       expect(subject.data).to be_empty
     end
+  end
+
+  describe "#diverge" do
+    let(:another_template) { double(:template, name: :another_conversation) }
+
+    xit "finds the conversation by name" do
+      template = Converse::ConversationTemplate.build(:another_conversation)
+      Converse.register_template template
+
+      conversation = subject.diverge :another_conversation
+
+      expect(conversation.template).to eq template
+    end
+
+    xit "calls the conversation with the channel and user"
+    xit "does nothing if the conversation doesn't exist"
   end
 
   describe "#end" do

--- a/spec/converse/conversation_template_runner_spec.rb
+++ b/spec/converse/conversation_template_runner_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Converse::ConversationTemplateRunner do
       after { Converse.conversations.clear }
 
       it "it creates a conversation" do
-        expect(Converse::Conversation).to receive(:new).with(template, nil, options)
+        expect(Converse::Conversation).to \
+          receive(:new).with(template, Converse::MessageDecorators::Slack, options)
           .and_call_original
 
         subject.run template
@@ -67,11 +68,10 @@ RSpec.describe Converse::ConversationTemplateRunner do
     end
 
     context "with a registered conversation" do
-      let(:conversation) { Converse::Conversation.new template, nil, options }
+      let(:conversation) { Converse::Conversation.new template, decorated_message, options }
+      let(:decorated_message) { Converse::MessageDecorators::Slack.new(message) }
 
       before do
-        conversation.user_id = user_id
-        conversation.channel_id = channel_id
         Converse.register_conversation conversation
       end
       after { Converse.conversations.clear }

--- a/spec/converse/conversation_template_runner_spec.rb
+++ b/spec/converse/conversation_template_runner_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Converse::ConversationTemplateRunner do
       after { Converse.conversations.clear }
 
       it "it creates a conversation" do
-        expect(Converse::Conversation).to receive(:new).with(template, options).and_call_original
+        expect(Converse::Conversation).to receive(:new).with(template, nil, options)
+          .and_call_original
 
         subject.run template
       end
@@ -66,7 +67,7 @@ RSpec.describe Converse::ConversationTemplateRunner do
     end
 
     context "with a registered conversation" do
-      let(:conversation) { Converse::Conversation.new template, options }
+      let(:conversation) { Converse::Conversation.new template, nil, options }
 
       before do
         conversation.user_id = user_id

--- a/spec/converse/conversation_template_runner_spec.rb
+++ b/spec/converse/conversation_template_runner_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Converse::ConversationTemplateRunner do
       end
 
       it "performs the conversation" do
-        expect_any_instance_of(Converse::Conversation).to receive(:perform).with message
+        expect_any_instance_of(Converse::Conversation).to receive(:perform)
 
         subject.run template
       end

--- a/spec/converse/conversation_template_runner_spec.rb
+++ b/spec/converse/conversation_template_runner_spec.rb
@@ -39,27 +39,6 @@ RSpec.describe Converse::ConversationTemplateRunner do
         subject.run template
       end
 
-      it "sets the user" do
-        expect_any_instance_of(Converse::Conversation).to \
-          receive(:user_id=).with(user_id).and_call_original
-
-        subject.run template
-      end
-
-      it "sets the channel" do
-        expect_any_instance_of(Converse::Conversation).to \
-          receive(:channel_id=).with(channel_id).and_call_original
-
-        subject.run template
-      end
-
-      it "sets the team" do
-        expect_any_instance_of(Converse::Conversation).to \
-          receive(:team_id=).with(team_id).and_call_original
-
-        subject.run template
-      end
-
       it "performs the conversation" do
         expect_any_instance_of(Converse::Conversation).to receive(:perform).with message
 

--- a/spec/converse/conversation_template_spec.rb
+++ b/spec/converse/conversation_template_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe Converse::ConversationTemplate do
   describe ".build" do
     let(:name) { :thread_one }
-    after { Converse.clear_templates }
 
     it "returns a new instance of a template" do
       expect(described_class.build(name)).to be_kind_of Converse::ConversationTemplate
@@ -33,6 +32,21 @@ RSpec.describe Converse::ConversationTemplate do
 
     it "takes in an optional thread name" do
       expect(described_class.build(:thread_one).name).to eq :thread_one
+    end
+  end
+
+  describe "#register" do
+    subject { described_class.new }
+    after { Converse.clear_templates }
+
+    it "returns the template to enable chaining" do
+      expect(subject.register).to eq subject
+    end
+
+    it "registers the conversation with the factory" do
+      subject.register
+
+      expect(Converse.templates).to include subject
     end
   end
 

--- a/spec/converse/message_decorators/slack_spec.rb
+++ b/spec/converse/message_decorators/slack_spec.rb
@@ -34,4 +34,12 @@ RSpec.describe Converse::MessageDecorators::Slack do
       expect(subject.user_id).to eq user_id
     end
   end
+
+  describe "delegating" do
+    it "delegates any other messages to the original message" do
+      allow(message).to receive(:text).and_return "Text"
+
+      expect(subject.text).to eq "Text"
+    end
+  end
 end

--- a/spec/features/diverging_a_conversation_spec.rb
+++ b/spec/features/diverging_a_conversation_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe "diverging a conversation" do
+  include Converse::Test::ConversationHelpers
+  include Converse::Test::SlackClientStubbing
+
+  let(:message) { double(:message, user: "U1234", channel: "C1234", team: "T1234") }
+
+  before { stub_slack_chat }
+
+  describe "diverging from a simple conversation to a simple conversation" do
+    it "runs the first step of the diverged conversation" do
+      Converse::ConversationTemplate.build(:ask_color) do |convo|
+        convo.ask "What color t-shirt do you want?" do |convo, response|
+          convo.end "Thank you!"
+        end
+      end.register
+
+      Converse::ConversationTemplate.build(:retrieve_shirt_specs) do |convo|
+        convo.ask "What size t-shirt do you want?" do |convo, response|
+          convo.diverge :ask_color
+        end
+      end.register.start message
+
+      answer_all_questions "XL", "black"
+
+      expect(stubbed_conversations.count).to eq 3
+      expect(stubbed_conversations.first).to eq "What size t-shirt do you want?"
+      expect(stubbed_conversations.second).to eq "What color t-shirt do you want?"
+      expect(stubbed_conversations.third).to eq "Thank you!"
+    end
+  end
+
+  describe "returning from a diverged conversation" do
+  end
+
+  describe "ending within a diverged conversation" do
+  end
+end

--- a/spec/features/diverging_a_conversation_spec.rb
+++ b/spec/features/diverging_a_conversation_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "diverging a conversation" do
   let(:message) { double(:message, user: "U1234", channel: "C1234", team: "T1234") }
 
   before { stub_slack_chat true }
+  after { Converse.clear_templates }
 
   describe "diverging from a simple conversation to a simple conversation" do
     it "runs the first step of the diverged conversation" do
@@ -30,8 +31,25 @@ RSpec.describe "diverging a conversation" do
   end
 
   describe "returning from a diverged conversation" do
-  end
+    it "runs the conversation after the diverge" do
+      Converse::ConversationTemplate.build(:ask_color) do |convo|
+        convo.ask "What color t-shirt do you want?"
+      end.register
 
-  describe "ending within a diverged conversation" do
+      Converse::ConversationTemplate.build(:retrieve_shirt_specs) do |convo|
+        convo.ask "What size t-shirt do you want?" do |convo, response|
+          convo.diverge :ask_color
+          convo.say "Thank you!"
+          convo.end
+        end
+      end.register.start message
+
+      answer_all_questions "XL", "black"
+
+      expect(stubbed_conversations.count).to eq 3
+      expect(stubbed_conversations.first).to eq "What size t-shirt do you want?"
+      expect(stubbed_conversations.second).to eq "What color t-shirt do you want?"
+      expect(stubbed_conversations.third).to eq "Thank you!"
+    end
   end
 end

--- a/spec/features/diverging_a_conversation_spec.rb
+++ b/spec/features/diverging_a_conversation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "diverging a conversation" do
 
   let(:message) { double(:message, user: "U1234", channel: "C1234", team: "T1234") }
 
-  before { stub_slack_chat }
+  before { stub_slack_chat true }
 
   describe "diverging from a simple conversation to a simple conversation" do
     it "runs the first step of the diverged conversation" do

--- a/spec/support/conversation_helpers.rb
+++ b/spec/support/conversation_helpers.rb
@@ -1,0 +1,13 @@
+module Converse
+  module Test
+    module ConversationHelpers
+      def answer_all_questions(*answers)
+        conversation = Converse.conversations.first
+
+        answers.each do |answer|
+          conversation.continue answer
+        end unless conversation.nil?
+      end
+    end
+  end
+end

--- a/spec/support/slack_client_stubbing.rb
+++ b/spec/support/slack_client_stubbing.rb
@@ -5,10 +5,10 @@ module Converse
         @stubbed_conversations ||= []
       end
 
-      def stub_slack_chat
+      def stub_slack_chat(record=false)
         allow_any_instance_of(::Slack::Web::Client).to \
           receive(:chat_postMessage) do |_client, arguments|
-          stubbed_conversations << arguments[:text]
+          stubbed_conversations << arguments[:text] if record
         end
       end
     end

--- a/spec/support/slack_client_stubbing.rb
+++ b/spec/support/slack_client_stubbing.rb
@@ -1,8 +1,15 @@
 module Converse
   module Test
     module SlackClientStubbing
+      def stubbed_conversations
+        @stubbed_conversations ||= []
+      end
+
       def stub_slack_chat
-        allow_any_instance_of(::Slack::Web::Client).to receive(:chat_postMessage)
+        allow_any_instance_of(::Slack::Web::Client).to \
+          receive(:chat_postMessage) do |_client, arguments|
+          stubbed_conversations << arguments[:text]
+        end
       end
     end
   end


### PR DESCRIPTION
Support the ability to diverge a conversation so a developer could branch to different conversations based on where a conversation could go.

Here is an example:

```
Converse::ConversationTemplate.build(:ask_color) do |convo|
  convo.ask "What color t-shirt do you want?" do |convo, response|
    convo.store! color: response
    convo.end "Thank you!"
  end
end.register

Converse::ConversationTemplate.build(:retrieve_shirt_specs) do |convo|
  convo.ask "What size do you want?" do |convo, response|
    convo.store! size: response
    convo.diverge :ask_color
  end
end.register
```

In order to support this, the API for a conversation changed from having a single `#template` property to a `templates` property as a conversation can now have multiple templates.