### PR TITLE
Support attachments

### DIFF
--- a/lib/converse/conversation.rb
+++ b/lib/converse/conversation.rb
@@ -56,9 +56,20 @@ module Converse
     alias_method :continue, :perform
 
     def say(statement, opts={})
+      ensure_registration
       Converse::Streams::Slack.new(options[:access_token])
         .puts statement, channel_id, user_id, opts
     end
     alias_method :reply, :say
+
+    private
+
+    def ensure_registration
+      # The conversation can be unregistered from a diverge, so let's ensure it
+      # is registered
+      if !Converse.conversation_registered? user_id, channel_id
+        Converse.register_conversation self
+      end
+    end
   end
 end

--- a/lib/converse/streams/slack.rb
+++ b/lib/converse/streams/slack.rb
@@ -12,6 +12,7 @@ module Converse
         text = output
         text = text.insert 0, "<@#{user_id}> " if opts[:direct_mention]
         options.merge!(text: text)
+        options.merge!(attachments: opts[:attachments]) if opts[:attachments]
         client.chat_postMessage options
       end
 

--- a/spec/converse/streams/slack_spec.rb
+++ b/spec/converse/streams/slack_spec.rb
@@ -28,5 +28,16 @@ RSpec.describe Converse::Streams::Slack do
 
       subject.puts statement, channel_id, user_id, { direct_mention: true }
     end
+
+    it "can send attachments" do
+      expect_any_instance_of(Slack::Web::Client).to \
+        receive(:chat_postMessage).with(channel: channel_id, as_user: true,
+                                        text: nil, attachments: [{
+          text: "Here's an attachment!"
+        }])
+
+      subject.puts nil, channel_id, user_id,
+        { attachments: [{ text: "Here's an attachment!"}] }
+    end
   end
 end

--- a/spec/features/diverging_a_conversation_spec.rb
+++ b/spec/features/diverging_a_conversation_spec.rb
@@ -8,6 +8,22 @@ RSpec.describe "diverging a conversation" do
   after { Converse.clear_templates }
 
   describe "diverging from a simple conversation to a simple conversation" do
+    it "unregisters the conversation when it's complete" do
+      Converse::ConversationTemplate.build(:first_step) do |convo|
+        convo.say "First step"
+      end.register
+
+      Converse::ConversationTemplate.build(:second_step) do |convo|
+        convo.diverge :first_step
+        convo.say "Second step"
+      end.register.start message
+
+      expect(Converse.conversations).to be_empty
+      expect(stubbed_conversations.count).to eq 2
+      expect(stubbed_conversations.first).to eq "First step"
+      expect(stubbed_conversations.second).to eq "Second step"
+    end
+
     it "runs the first step of the diverged conversation" do
       Converse::ConversationTemplate.build(:ask_color) do |convo|
         convo.ask "What color t-shirt do you want?" do |convo, response|
@@ -28,6 +44,24 @@ RSpec.describe "diverging a conversation" do
       expect(stubbed_conversations.first).to eq "What size t-shirt do you want?"
       expect(stubbed_conversations.second).to eq "What color t-shirt do you want?"
       expect(stubbed_conversations.third).to eq "Thank you!"
+    end
+  end
+
+  describe "diverging at the end from a simple conversation" do
+    it "unregisters the conversation when it's complete" do
+      Converse::ConversationTemplate.build(:second_step) do |convo|
+        convo.say "Second step"
+      end.register
+
+      Converse::ConversationTemplate.build(:first_step) do |convo|
+        convo.say "First step"
+        convo.diverge :second_step
+      end.register.start message
+
+      expect(Converse.conversations).to be_empty
+      expect(stubbed_conversations.count).to eq 2
+      expect(stubbed_conversations.first).to eq "First step"
+      expect(stubbed_conversations.second).to eq "Second step"
     end
   end
 

--- a/spec/features/diverging_a_conversation_spec.rb
+++ b/spec/features/diverging_a_conversation_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "diverging a conversation" do
 
       answer_all_questions "XL", "black"
 
+      expect(Converse.conversations).to be_empty
       expect(stubbed_conversations.count).to eq 3
       expect(stubbed_conversations.first).to eq "What size t-shirt do you want?"
       expect(stubbed_conversations.second).to eq "What color t-shirt do you want?"
@@ -46,10 +47,31 @@ RSpec.describe "diverging a conversation" do
 
       answer_all_questions "XL", "black"
 
+      expect(Converse.conversations).to be_empty
       expect(stubbed_conversations.count).to eq 3
       expect(stubbed_conversations.first).to eq "What size t-shirt do you want?"
       expect(stubbed_conversations.second).to eq "What color t-shirt do you want?"
       expect(stubbed_conversations.third).to eq "Thank you!"
+    end
+  end
+
+  describe "diverging to simple step and then returning" do
+    it "runs the conversation after the diverge" do
+      Converse::ConversationTemplate.build(:ready_statement) do |convo|
+        convo.say "We are ready!"
+      end.register
+
+      Converse::ConversationTemplate.build(:retrieve_shirt_size) do |convo|
+        convo.diverge :ready_statement
+        convo.ask "What size t-shirt do you want?" do |convo, response|
+          convo.ask "What color t-shirt do you want?"
+        end
+      end.register.start message
+
+      answer_all_questions "XL", "black"
+
+      expect(Converse.conversations).to be_empty
+      expect(stubbed_conversations.count).to eq 3
     end
   end
 end


### PR DESCRIPTION
Allows a conversation to add [Slack attachments](https://api.slack.com/docs/message-attachments) to the Slack stream object. These are just a hash representation of the attachment.

```
Converse::ConversationTemplate.build(:demo_attachment) do |convo|
  convo.ask "What size do you want?", { attachments: [{
    # build attachment here
    }]
  } do |convo, response|
  end
end.register
```

In addition, this also fixes an issue with [diverging a conversation](#4) where the conversation could get unregistered after it was diverged.