### PR TITLE
Prepare for gem release

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ This will register the conversation for the user and channel with the factory an
 - [ ] Add support for Facebook
 - [ ] Add support for persistent conversations (serializable proc)
 
+## RELEASING A NEW GEM
+
+1. Bump the VERSION in `lib/dialogue/version.rb`
+1. Commit changes and push to GitHub
+1. run `bundle exec rake release`
+
 ## LICENSE
 
 Copyright (c) 2016, [Tatsu, Inc.](http://tatsu.io).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Dialogue
 ========
 
+[ ![Codeship Status for tatsuio/dialogue](https://app.codeship.com/projects/9afef670-f132-0134-a265-7e8cdab40218/status?branch=master)](https://app.codeship.com/projects/209305)
+
 ## DESCRIPTION
 
 A DSL for defining conversations and workflows in Ruby. The conversations follow those workflows based on incoming messages and their intents.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec


### PR DESCRIPTION
Add rake tasks to make it easier to release a gem.

Add Codeship for continuous integration.