### PR TITLE
8 conversation with data

### DIFF
--- a/lib/dialogue/conversation.rb
+++ b/lib/dialogue/conversation.rb
@@ -26,6 +26,7 @@ module Dialogue
         @user_id = message.user_id
       end
 
+      @data = options.delete(:data)
       @options = options.freeze
     end
 

--- a/lib/dialogue/conversation_options_validator.rb
+++ b/lib/dialogue/conversation_options_validator.rb
@@ -1,6 +1,6 @@
 module Dialogue
   class ConversationOptionsValidator
-    VALID_OPTIONS = [:access_token, :author_id].freeze
+    VALID_OPTIONS = [:access_token, :author_id, :data].freeze
 
     def validate(options)
       errors = []

--- a/lib/dialogue/conversation_template_runner.rb
+++ b/lib/dialogue/conversation_template_runner.rb
@@ -8,7 +8,7 @@ module Dialogue
       guard_options! options
 
       @message = message
-      @options = options.freeze
+      @options = options
     end
 
     def channel_id

--- a/lib/dialogue/message_decorators/slack.rb
+++ b/lib/dialogue/message_decorators/slack.rb
@@ -1,3 +1,5 @@
+require "delegate"
+
 module Dialogue
   module MessageDecorators
     class Slack < SimpleDelegator

--- a/spec/dialogue/conversation_options_validator_spec.rb
+++ b/spec/dialogue/conversation_options_validator_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Dialogue::ConversationOptionsValidator do
   describe "::VALID_OPTIONS" do
     it "returns the valid option keys" do
-      expect(described_class::VALID_OPTIONS).to eq [:access_token, :author_id]
+      expect(described_class::VALID_OPTIONS).to \
+        eq [:access_token, :author_id, :data]
     end
   end
 

--- a/spec/features/diverging_a_conversation_spec.rb
+++ b/spec/features/diverging_a_conversation_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe "diverging a conversation" do
   let(:message) { double(:message, user: "U1234", channel: "C1234", team: "T1234") }
 
   before { stub_slack_chat true }
-  after { Dialogue.clear_templates }
+  after do
+    Dialogue.clear_conversations
+    Dialogue.clear_templates
+  end
 
   describe "diverging from a simple conversation to a simple conversation" do
     it "unregisters the conversation when it's complete" do

--- a/spec/features/registering_a_conversation_spec.rb
+++ b/spec/features/registering_a_conversation_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe "registering a conversation" do
                          team: "T1234") }
 
   before { stub_slack_chat true }
-  after { Dialogue.clear_templates }
+  after do
+    Dialogue.clear_conversations
+    Dialogue.clear_templates
+  end
 
   describe "registering a conversation with data" do
     it "adds the data to the conversation" do

--- a/spec/features/registering_a_conversation_spec.rb
+++ b/spec/features/registering_a_conversation_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe "registering a conversation" do
+  include Dialogue::Test::SlackClientStubbing
+
+  let(:message) { double(:message, user: "U1234", channel: "C1234",
+                         team: "T1234") }
+
+  before { stub_slack_chat true }
+  after { Dialogue.clear_templates }
+
+  describe "registering a conversation with data" do
+    it "adds the data to the conversation" do
+      Dialogue::ConversationTemplate.build(:template) do |convo|
+        convo.ask "How are you?"
+      end.register.start message, { data: { parameter1: "value1" } }
+
+      expect(Dialogue.conversations.count).to eq 1
+      expect(Dialogue.conversations.first.fetch(:parameter1)).to eq "value1"
+    end
+  end
+end


### PR DESCRIPTION
Allows specifying `data` as an option when a conversation starts. This is good to use when using conversations with an NLP layer that returns parameters.

The data that is specified in the options is applied as data on the `Conversation::Storable` module so the conversation starts out with these data points.

Closes #8 