### PR TITLE
10 - fix has_data

### DIFF
--- a/lib/dialogue/storable.rb
+++ b/lib/dialogue/storable.rb
@@ -13,8 +13,7 @@ module Dialogue
       if present
         present = keys.all? do |key|
           !data[key].nil? &&
-            (!data[key].respond_to?(:empty?) ||
-             (data[key].respond_to?(:empty?) && !data[key].empty?))
+            (!data[key].respond_to?(:empty?) || !data[key].empty?)
         end
       end
       present

--- a/lib/dialogue/storable.rb
+++ b/lib/dialogue/storable.rb
@@ -13,7 +13,8 @@ module Dialogue
       if present
         present = keys.all? do |key|
           !data[key].nil? &&
-            (data[key].respond_to?(:empty?) && !data[key].empty?)
+            (!data[key].respond_to?(:empty?) ||
+             (data[key].respond_to?(:empty?) && !data[key].empty?))
         end
       end
       present

--- a/spec/dialogue/conversation_spec.rb
+++ b/spec/dialogue/conversation_spec.rb
@@ -150,6 +150,13 @@ RSpec.describe Dialogue::Conversation do
       expect(subject).to_not have_data(:key1, :key2)
     end
 
+    it "returns true if none of the keys are empty" do
+      subject.store!(key1: Date.today)
+      subject.store!(key2: :value2)
+
+      expect(subject).to have_data(:key1, :key2)
+    end
+
     it "returns false if one of the keys is empty" do
       subject.store!(key1: [])
       subject.store!(key2: :value2)


### PR DESCRIPTION
There was a bug with the logic for `Storable#has_data?` where if a value did not respond to the `#empty?` message but was not `nil`, then the method would still return `false`.

This checks to ensure the value responds to the message.

Fixes #10.